### PR TITLE
Only use runas wrapper if runas.username and runas.password are set

### DIFF
--- a/runas-agent/src/org/jetbrains/teamcity/runas/RunAsCommandLineProcessor.java
+++ b/runas-agent/src/org/jetbrains/teamcity/runas/RunAsCommandLineProcessor.java
@@ -26,7 +26,24 @@ public class RunAsCommandLineProcessor implements BuildCommandLineProcessor {
     throws RunBuildException {
     final AgentRunningBuild build = runnerContext.getBuild();
     final String execPath = getCustomExecutableCommand(build);
-    if (execPath == null) return origCommandLine;
+    Map<String, String> props = build.getSharedConfigParameters();
+
+    /*
+    BuildProgressLogger logger = build.getBuildLogger();
+
+    for(String i : props.keySet()) {
+        logger.message("Key: " + i + " Value: " + props.get(i));
+    }
+    */
+
+    final Boolean useRunas =
+            (
+                    ( props.containsKey("runas.username") && !props.get("runas.username").isEmpty() )
+                    &&
+                    ( props.containsKey("runas.password") && !props.get("runas.password").isEmpty() )
+            );
+
+    if (execPath == null || !useRunas) return origCommandLine;
 
     final File script = createScriptFile(origCommandLine, build);
 


### PR DESCRIPTION
This patch allows builds on a single agent to be configured to use the runas plugin (by setting the parameters) or to just run the build as the current user (by leaving them blank or unset).

Thanks for all the TeamCity goodness!
